### PR TITLE
Update properties file for RollingAvgStats

### DIFF
--- a/PerfHarness/src/com/ibm/uk/hursley/perfharness/stats/RollingAvgStats.properties
+++ b/PerfHarness/src/com/ibm/uk/hursley/perfharness/stats/RollingAvgStats.properties
@@ -7,14 +7,14 @@
 # http://opensource.org/licenses/MIT
 ########################################################## {COPYRIGHT-END} ###
 
-com.ibm.uk.hursley.perfharness.RollingAvgStats.desc=\
+com.ibm.uk.hursley.perfharness.stats.RollingAvgStats.desc=\
 Prints the average of performance over the last 30 seconds on a periodic basis.  The\n\
 final summary is the average duration of the WorkerThreads and the maximum\n\
-rolling average achieved during that period. 
+rolling average achieved during that period.
 
 sr.dflt = 30
 sr.desc = Rolling average period (seconds).
 sr.type = java.lang.Integer
 sr.xtra = Performance is sampled every second, the number reported is the\n\
 average over the last rolling average period.  During the first period, the\n\
-figure reported is the average over the actual number of seconds elapsed. 
+figure reported is the average over the actual number of seconds elapsed.


### PR DESCRIPTION
The properties file for the RollingAvgStats description had an incorrect package string which meant the information was not displayed under help. Fixing the package enables the description to be viewed.